### PR TITLE
Fix memory corruption

### DIFF
--- a/widgetstyle/basestyle.cpp
+++ b/widgetstyle/basestyle.cpp
@@ -4289,7 +4289,8 @@ QSize BaseStyle::sizeFromContents(ContentsType type,
     }
     case CT_Slider: {
         QSize sz = size;
-        if (qobject_cast<const QSlider*>(widget)->orientation() == Qt::Horizontal) {
+        // mitigate zero-pointer dereference
+        if (!widget || qobject_cast<const QSlider*>(widget)->orientation() == Qt::Horizontal) {
             sz.setHeight(sz.height() + PM_SliderTickmarkOffset);
         } else {
             sz.setWidth(sz.width() + PM_SliderTickmarkOffset);


### PR DESCRIPTION
To produce the bug, open KDE `systemsettings5` and click on "Workspace Behavior", the "General Behavior" tab will trigger the bug and crash the settings app. Running it in gdb confirms that `widget = 0`

After the update, both KDE settings and cutefish settings can run smoothly.